### PR TITLE
 clarify purpose of api at start of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 # Unofficial TikTok API Wrapper in Python
 
 This is an unofficial TikTok Api python wrapper. I have an App using this API, and thus will constantly keep updating this wrapper  
-This implementation is inspired by [TikTokApi](https://github.com/davidteather/TikTok-Api/), but runs faster.  
+This implementation is inspired by [TikTokApi](https://github.com/davidteather/TikTok-Api/), but runs faster.
 
+This api is made to retrieve data **from** TikTok. It **can not be used post or upload** content **to** TikTok in behalf of a user.
 
 ## Table of Contents
 - [Getting Started](#getting-started)


### PR DESCRIPTION
I've added two short sentences at the beginning of the README, which clarify that this api is not meant to schedule, post or upload content to TikTok. Thus these sentences make clear that the api is build to retrieve data from TikTok.